### PR TITLE
Keep coherent version numbers (package.json <> bower.json)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "pagedown",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "authors": [
     "Original Showdown code copyright (c) 2007 John Fraser",
     "Original Markdown Copyright (c) 2004-2005 John Gruber <http://daringfireball.net/projects/markdown/>",


### PR DESCRIPTION
It would be interesting to keep version coherent between the official version, the NPM package and the Bower package.

Could you merge this pull request and create a new tag for this version?

Cheers!
LL
